### PR TITLE
:bug: Fixed bad grid container sizing in Chromium

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,8 @@
       grid-template-columns: repeat(12, 1fr);
       grid-auto-rows: max-content;
       column-gap: var(--text-base);
+      
+      width: 100%;
     }
 
     .span-2 {


### PR DESCRIPTION
Found that, in Chromium browsers, grid containers collapsed to awkward sizes. To
fix this, the grid containers now have a fixed with of 100% their parent width.